### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -410,7 +410,7 @@ if __name__ == '__main__':
     # Start the Flask development server
     # debug=True enables debug mode, which shows detailed error messages and enables hot reloading
     # host='0.0.0.0' makes the server accessible from any IP address
-    app.run(debug=True, host='0.0.0.0', port=8000)
+    app.run(debug=os.environ.get("FLASK_DEBUG") == "1", host='0.0.0.0', port=8000)
 
 # For Vercel deployment
 # This exposes the Flask application as a module-level variable


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/path/security/code-scanning/2](https://github.com/bniladridas/path/security/code-scanning/2)

To address this problem, we should ensure that the Flask app is not run in debug mode by default, especially not with `debug=True` hardcoded. A secure way to manage this is to control the debug setting via an environment variable (e.g., `FLASK_DEBUG`) or to simply default to `debug=False`. Since the comments suggest this is a local development block and since we should not change existing deployment functionality, the best approach is either:
- Remove `debug=True` entirely, or 
- Set `debug` based on a secure environment variable, defaulting to `False`.

For minimal change and maximum safety, replace `debug=True` with `debug=os.environ.get("FLASK_DEBUG") == "1"`. This way, debug mode is only enabled intentionally by the developer via environment configuration.

The code to change is in `app.py`, specifically line 413. Optionally, add an import for `os` if it was not already present (but in this case, `os` is already imported at line 22, so no import is needed).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
