### PR TITLE
ci: Add bundler support for Ruby dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,20 +53,40 @@ updates:
       - "github-actions"
       - "dependencies"
 
-  # Docker (if applicable)
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
-    reviewers:
-      - "bniladridas"
-    assignees:
-      - "bniladridas"
-    commit-message:
-      prefix: "docker"
-      include: "scope"
-    labels:
-      - "docker"
-      - "dependencies"
+   # Docker (if applicable)
+   - package-ecosystem: "docker"
+     directory: "/"
+     schedule:
+       interval: "monthly"
+     open-pull-requests-limit: 3
+     reviewers:
+       - "bniladridas"
+     assignees:
+       - "bniladridas"
+     commit-message:
+       prefix: "docker"
+       include: "scope"
+     labels:
+       - "docker"
+       - "dependencies"
+
+   # Ruby gems (Bundler)
+   - package-ecosystem: "bundler"
+     directory: "/"
+     schedule:
+       interval: "weekly"
+       day: "monday"
+       time: "06:00"
+     open-pull-requests-limit: 5
+     reviewers:
+       - "bniladridas"
+     assignees:
+       - "bniladridas"
+     commit-message:
+       prefix: "deps"
+       prefix-development: "deps-dev"
+       include: "scope"
+     labels:
+       - "dependencies"
+       - "ruby"
 


### PR DESCRIPTION
Adds bundler ecosystem to dependabot.yml to enable automatic updates for Ruby gems.