### PR TITLE
deps: Downgrade Flask to 3.0.3 for Python 3.8 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask==3.1.2
+flask==3.0.3
 python-dotenv==1.0.1
 requests==2.32.5
 gunicorn==23.0.0


### PR DESCRIPTION
This PR fixes the CI failure that occurred after merging dependabot/pip/flask-3.1.2 (PR #29).

## Problem
The CI was failing with:

This happened because Flask 3.1.2 requires Python 3.9+, but the CI environment was running Python 3.8.

## Solution
Downgrade Flask to 3.0.3, which is the latest version compatible with Python 3.8. This ensures compatibility across different Python versions in CI.

## Changes
- Updated requirements.txt: Flask==3.1.2 → Flask==3.0.3