### PR TITLE
ci: Align Python versions in CI with Dockerfile

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests and lint with multiple versions of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -17,12 +17,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This PR aligns the Python versions used in CI with the production Dockerfile to prevent version mismatches and ensure consistency.

## Changes
- Updated .github/workflows/python-app.yml to use a matrix strategy testing Python 3.9 and 3.10
- This matches the Dockerfile's python:3.10-slim base image
- Ensures compatibility across Python versions and prevents future dependency issues

## Why
Running different Python versions in CI and production can lead to subtle bugs. By testing both 3.9 and 3.10, we ensure the app works across these versions while aligning with production.